### PR TITLE
0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Mind that currently only a part of data available is covered.
 There are 3 types of classes which present data in the same way, but differ a bit in handling:
 - EnmetEntity subclasses: they represent "native" Metal Archives objects - this means objects which have their own identifiers in Metal Archives. Examples of these subclasses are Artist, Band, Album, Track etc. All they have `id` property containing relevant identifier. 
 - DynamicEnmetEntity subclasses: they represent "dynamic" Metal Archives objects - entities, which don't have their identities in Metal Archives and thus no identifiers. Examples of these subclasses are `Disc` and `AlbumArtist`. Creation of these subclasses was necessary to preserve natural logic when manipulating entity objects; for example name of an album artist (represented by class `AlbumArtist`) stated on a physical media can be different from what appears on the artist's page in Metal Archives as name or full name.
-- ExternalEntity: objects of these class represent entities external to Metal Archives, for example non-metal artist of a collaboration album. The objects have just a single property `name`. These entities have no own data pages in MetalArchives, they are just mentioned by name.
+- ExternalEntity: objects of these class represent entities external to Metal Archives, for example non-metal artist of a collaboration album. The objects have the property `name` and other properties depending on concrete object purpose. These entities have no own data pages in MetalArchives, they are just mentioned by name.
 
 ### Creating objects
 
@@ -111,6 +111,9 @@ Note: Any "empty" values are returned as `None` or `[]`. This refers both to val
     - `discs(self) -> List[Disc]`
     - `lineup(self) -> List[AlbumArtist]`
     - `total_time(self) -> timedelta`
+    - `guest_session_musicians(self) -> List["AlbumArtist"]`
+    - `other_staff(self) -> List["AlbumArtist"]`
+    - `additional_notes(self) -> str`
 - `AlbumArtist(_EntityArtist)`. This class represent an artist performing on a specific album.
   - `__init__(self, id_: str, album_id: str, *, name: str = None, role: str = None)`. `id_` is the artist's identifier in Metal Archives. `album_id` is an album's identifier. `name` is the artist's name as stated on the album. `role` is the artist's role on the album.
   - Attributes and properties:
@@ -129,6 +132,11 @@ Note: Any "empty" values are returned as `None` or `[]`. This refers both to val
     - `gender(self) -> str`
     - `biography(self) -> str`
     - `trivia(self) -> str`
+    - `active_bands(self) -> Dict[Union[Band, ExternalEntity], List[Album]]`
+    - `past_bands(self) -> Dict[Union[Band, ExternalEntity], List[Album]]`
+    - `guest_session(self) -> Dict[Union[Band, ExternalEntity], List[Album]]`
+    - `misc_staff(self) -> Dict[Union[Band, ExternalEntity], List[Album]]`
+    - `links(self) -> List[Tuple[str, str]]`
 - `Band(EnmetEntity)`. This class represents a band.
   - `__init__(self, id_: str, *, name: str = None, country: Countries = None)`. `id_` is the band's identifier in Metal Archives. `name` is the band's name as stated on the band's page. `country` is the band's country of origin.
   - Attributes and properties:
@@ -227,7 +235,7 @@ There are two object layers used:
     1. Subclasses of `SearchResultPage(Page)` represent responses to search HTTP requests. They have a single property that returns a list, where each list element is a tuple of simple data pertaining to a single found entity (`List[Tuple[str, ...]]`) - for example a list where each element is (band name, band country, formation year) tuple. These subclasses process JSON returned by requests sent to search resources.
     2. Subclasses of `DataPage(Page)` represent responses to entity HTTP requests. Sometimes a `DataPage` subclass represents just what can be seen in a browser for an entity, but most of the time there is no 1:1 correspondence between what a user sees in a browser and some `DataPage` subclass. These subclasses have multiple properties that make available different pieces of data found on the corresponding webpages. `_CachedSite` descriptor in `_DataPage` class returns BeautifulSoup objects for requests, thus data extraction in `_DataPage` subclasses is done with CSS selectors. 
 2. Concrete subclassess of `Entity` class represent items like band, album or track. They use `DataPage` objects and other `Entity` objects to present full entity via properties. There are 3 types of `Entity` subclasses:
-   1. Class `ExternalEntity` represents entity from outside of The Metal Archives (without MA id), like non-metal musician without MA page participating in a release. This class has single property `name`, which provides simple textual information about the entity.
+   1. Class `ExternalEntity` represents entity from outside of The Metal Archives (without MA id), like non-metal musician without MA page participating in a release. This class has property `name`, which provides simple textual information about the entity, and other properties depending on what the object represents.
    2. Class `EnmetEntity` represents Metal Archives entity which has its own id (like band).
    3. Class `DynamicEnmetEntity` represents Metal Archives entity without own identity (id). Using this class was necessary in order to be able all availabe information in consistent and logical manner.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "enmet"
-version = "0.4.1"
+version = "0.5.0b"
 description = "Python API for Encyclopaedia Metallum (The Metal Archives) website."
 readme = {text = """
 Enmet is a programmatic API to Encyclopaedia Metallum - The Metal Archives site. It allows convenient access to Metal Archives data from python code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "enmet"
-version = "0.5.0b"
+version = "0.5.0"
 description = "Python API for Encyclopaedia Metallum (The Metal Archives) website."
 readme = {text = """
 Enmet is a programmatic API to Encyclopaedia Metallum - The Metal Archives site. It allows convenient access to Metal Archives data from python code.

--- a/src/enmet/entities.py
+++ b/src/enmet/entities.py
@@ -301,7 +301,7 @@ class Disc(DynamicEnmetEntity):
     def tracks(self) -> List["Track"]:
         tracks = []
         for t in self._album_page.tracks[self._number]:
-            tracks.append(Track(t[0], self._bands, t[1], t[2], _timestr_to_time(t[3]), t[4]))
+            tracks.append(Track(t[0], self._bands, int(t[1]), t[2], _timestr_to_time(t[3]), t[4]))
         return tracks
 
 
@@ -402,19 +402,19 @@ class Artist(EnmetEntity):
         return result
 
     @cached_property
-    def active_bands(self) -> Dict[Band, List[Album]]:
+    def active_bands(self) -> Dict[Union[Band, ExternalEntity], List[Album]]:
         return self._get_bands("active_bands")
 
     @cached_property
-    def past_bands(self) -> Dict[Band, List[Album]]:
+    def past_bands(self) -> Dict[Union[Band, ExternalEntity], List[Album]]:
         return self._get_bands("past_bands")
 
     @cached_property
-    def guest_session(self) -> Dict[Band, List[Album]]:
+    def guest_session(self) -> Dict[Union[Band, ExternalEntity], List[Album]]:
         return self._get_bands("guest_session")
 
     @cached_property
-    def misc_staff(self) -> Dict[Band, List[Album]]:
+    def misc_staff(self) -> Dict[Union[Band, ExternalEntity], List[Album]]:
         return self._get_bands("misc_staff")
 
     @cached_property

--- a/src/enmet/entities.py
+++ b/src/enmet/entities.py
@@ -64,6 +64,12 @@ class ExternalEntity(Entity):
     def __dir__(self) -> Iterable[str]:
         return vars(self)
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        return hash(tuple(sorted((k, getattr(self, k)) for k in vars(self))))
+
 
 class EnmetEntity(Entity, CachedInstance, ABC):
     def __init__(self, id_):

--- a/src/enmet/pages.py
+++ b/src/enmet/pages.py
@@ -5,7 +5,7 @@ from functools import cached_property, lru_cache
 from os.path import expandvars, expanduser
 from pathlib import Path
 from time import sleep
-from typing import List, Tuple, Union, Optional, Type
+from typing import List, Tuple, Union, Optional, Type, Dict
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup, Tag, ResultSet
@@ -322,7 +322,7 @@ class AlbumPage(_DataPage):
             return None, elem.text
 
     @cached_property
-    def tracks(self) -> List[List[Union[str, Optional[bool]]]]:
+    def tracks(self) -> List[List[Union[int, str, Optional[bool]]]]:
         result = [[]]
         for elem in self.enmet.select_one("#album_tabs_tracklist").select("tr.even,tr.odd,.discRow"):
             if "discRow" in elem["class"]:
@@ -356,15 +356,30 @@ class AlbumPage(_DataPage):
     def total_times(self) -> List[Optional[str]]:
         return [e.text for e in self.enmet.select(".table_lyrics strong")] or [None]
 
-    @cached_property
-    def lineup(self):
+    def _get_people(self, group_id: str) -> List[List[str]]:
         result = []
-        for elem in self.enmet.select("#album_members_lineup tr.lineupRow"):
+        for elem in self.enmet.select(f"{group_id} tr.lineupRow"):
             # Artist URL, Artist
             result.append([elem.select_one("a")["href"], elem.select_one("a").text])
             # Role
             result[-1].append(elem.select_one("td:nth-child(2)").text.strip())
         return result
+
+    @cached_property
+    def lineup(self) -> List[List[str]]:
+        return self._get_people("#album_members_lineup")
+
+    @cached_property
+    def guest_session_musicians(self) -> List[List[str]]:
+        return self._get_people("#album_members_guest")
+
+    @cached_property
+    def other_staff(self) -> List[List[str]]:
+        return self._get_people("#album_members_misc")
+
+    @cached_property
+    def additional_notes(self) -> str:
+        return self.enmet.select_one("#album_tabs_notes").text.strip()
 
 
 class ArtistPage(_DataPage):
@@ -421,6 +436,69 @@ class ArtistPage(_DataPage):
     @cached_property
     def trivia(self) -> Optional[str]:
         return self._get_extended_section("Trivia", _ArtistTriviaPage)
+
+    def _get_band_tab(self, tab: str) -> Dict[Tuple[str, ...], List[Tuple[str, ...]]]:
+        result = {}
+        # Process band sections
+        for section in self.enmet.select(tab + " div.member_in_band"):
+            band_url = band_name = band_role = name_in_lineup = None
+            # Band url and name
+            band = section.select_one(".member_in_band_name")
+            if band_data := band.select_one("a"):
+                band_url, band_name = band_data["href"], band_data.text
+            else:
+                band_name = band.text
+            # Role and name in lineup
+            band_member_data = section.select_one(".member_in_band_role").text.strip().replace("\n", " ")
+            name_in_lineup = self.name
+            if match := re.search(r"As (.+): (.+)", band_member_data, re.I):
+                band_role = match.group(2)
+                name_in_lineup = match.group(1)
+            else:
+                band_role = band_member_data
+            # Add band entry to results
+            key = band_url, band_name, band_role, name_in_lineup
+            result[key] = []
+            # Process rows in band section
+            for entry in section.select("table tr"):
+                if "show all" in entry.text:
+                    continue
+                album_url = album_name = album_role = name_on_album = None
+                # Album url and name
+                album = entry.select_one("td:nth-of-type(2)")
+                album_url, album_name = album.select_one("a")["href"], album.select_one("a").text
+                # Role and name on album
+                album_role = entry.select_one("td:nth-of-type(3)").text.strip()
+                name_on_album = name_in_lineup or self.name
+                if match := re.search(r'(.+) \(as "(.+)"\)', album_role, re.I):
+                    album_role, name_on_album = match.group(1), match.group(2)
+                # Add album entry for the band to results
+                result[key].append([album_url, album_name, album_role, name_on_album])
+        return result
+
+    @cached_property
+    def active_bands(self) -> Dict[Tuple[str, ...], List[Tuple[str, ...]]]:
+        return self._get_band_tab("#artist_tab_active")
+
+    @cached_property
+    def past_bands(self) -> Dict[Tuple[str, ...], List[Tuple[str, ...]]]:
+        return self._get_band_tab("#artist_tab_past")
+
+    @cached_property
+    def guest_session(self) -> Dict[Tuple[str, ...], List[Tuple[str, ...]]]:
+        return self._get_band_tab("#artist_tab_guest")
+
+    @cached_property
+    def misc_staff(self) -> Dict[Tuple[str, ...], List[Tuple[str, ...]]]:
+        return self._get_band_tab("#artist_tab_misc")
+
+    @cached_property
+    def links(self) -> List[Tuple[str, str]]:
+        result = []
+        links = self.enmet.select("#linksTablemain a")
+        for link in links:
+            result.append((link["href"], link.text))
+        return result
 
 
 class _ArtistBiographyPage(_DataPage):

--- a/src/enmet/pages.py
+++ b/src/enmet/pages.py
@@ -333,7 +333,7 @@ class AlbumPage(_DataPage):
             result[-1].append([elem.select_one("td:nth-of-type(1) a")["name"]])
             # Number
             number = elem.select_one("td:nth-of-type(1)").text
-            result[-1][-1].append(int(number[:number.index(".")]))
+            result[-1][-1].append(number[:number.index(".")])
             # Name
             result[-1][-1].append(elem.select_one("td:nth-of-type(2)").text.strip())
             # Time

--- a/src/enmet/pages.py
+++ b/src/enmet/pages.py
@@ -494,8 +494,9 @@ class ArtistPage(_DataPage):
 
     @cached_property
     def links(self) -> List[Tuple[str, str]]:
+        data = _ArtistLinksPage(self.id).links
         result = []
-        links = self.enmet.select("#linksTablemain a")
+        links = data.select("a")
         for link in links:
             result.append((link["href"], link.text))
         return result
@@ -515,6 +516,14 @@ class _ArtistTriviaPage(_DataPage):
     @cached_property
     def trivia(self) -> str:
         return self.enmet.text
+
+
+class _ArtistLinksPage(_DataPage):
+    RESOURCE = "link/ajax-list/type/person/id/{}"
+
+    @cached_property
+    def links(self) -> str:
+        return self.enmet
 
 
 class LyricsPage(_DataPage):


### PR DESCRIPTION
- Extend ExternalEntity to have properties other than `name` (context dependant).
- Added to Album: guest_session_musicians, other_staff, additional_notes
- Added to Artist: active_bands, past_bands, guest_session, misc_staff, links